### PR TITLE
Version 1.1.5: New author identification path.

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "SciDataContainer"
-version = "1.1.4"
+version = "1.1.5"
 authors = [
   { name="Reinhard Caspary", email="reinhard.caspary@phoenixd.uni-hannover.de" },
 ]

--- a/python/scidatacontainer/__init__.py
+++ b/python/scidatacontainer/__init__.py
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright (c) 2023 Reinhard Caspary                                    #
+# Copyright (c) 2023-2024 Reinhard Caspary                               #
 # <reinhard.caspary@phoenixd.uni-hannover.de>                            #
 # This program is free software under the terms of the MIT license.      #
 ##########################################################################

--- a/python/scidatacontainer/__init__.py
+++ b/python/scidatacontainer/__init__.py
@@ -25,6 +25,7 @@
 __all__ = [
     "timestamp",
     "modelVersion",
+    "load_config",
     "register",
     "Container",
 ]
@@ -34,6 +35,7 @@ from importlib import import_module
 
 from .container import MODELVERSION as modelVersion
 from .container import AbstractContainer, timestamp
+from .config import load_config
 from .filebase import AbstractFile
 
 __version__ = "1.1.4"

--- a/python/scidatacontainer/config.py
+++ b/python/scidatacontainer/config.py
@@ -33,40 +33,49 @@ import os
 import platform
 
 
-def load_config(config_path: str = None) -> dict:
-    """Get config data from environment variables and config file.
+def load_config(config_path: str = None, **kwargs) -> dict:
+    
+    """Get author identity and server configuration.
 
-    This functions prefers values in the scidata config file and potentially
-    overwrites values that are present as environmental variables.
+    This function uses kwargs, the scidata config file and environmental
+    variables as sources for each parameter. The former sources
+    overriding the latter ones.
 
-    Usually, users doen't need to call this function. However, it can be used
-    for debugging purposes if the configuration parameters are not as expected.
+    Users may use the result of this function to inject the author
+    identity when building a new container:
+
+    config = load_config(author="John Doe", email="john@doe.com")
+    dc = Container(config=config)
 
     Args:
         str: Path of the config file. If this is None, the default file will
              be used. This filename is only required for testing.
 
+        kwargs: Parameter values as keyword arguments.
+        
     Returns:
         dict: A dictionary containing information strings with keys "author",\
-              "email", "server", "key".
+              "email", "orcid", "organization", "server", "key".
     """
 
     # Initialize config dictionary
-    config = {"author": "", "email": "", "server": "", "key": ""}
+    config = {"author": "", "email": "", "orcid": "",
+              "organization": "", "server": "", "key": ""}
 
     # Get default values from environment variables
     for key in config:
         name = "DC_%s" % key.upper()
         if name in os.environ:
-            config[key] = os.environ[name]
+            config[key] = os.environ[name].strip()
 
-    # Get default values from config file
+    # Path to scidata config file
     if not config_path:
         if platform.system() == "Windows":
             config_path = os.path.join(os.path.expanduser("~"), "scidata.cfg")
         else:
             config_path = os.path.join(os.path.expanduser("~"), ".scidata")
 
+    # Get default values from config file
     if os.path.exists(config_path):
         with open(config_path, "r") as fp:
             for line in fp.readlines():
@@ -80,5 +89,10 @@ def load_config(config_path: str = None) -> dict:
                 if key in config:
                     config[key] = line[1].strip()
 
+    # Use keyword arguments
+    for key in config:
+        if key in kwargs:
+            config[key] = kwargs[key].strip()
+    
     # Return config dictionary
     return config

--- a/python/scidatacontainer/config.py
+++ b/python/scidatacontainer/config.py
@@ -1,18 +1,20 @@
 ##########################################################################
-# Copyright (c) 2023 Reinhard Caspary                                    #
+# Copyright (c) 2023-2024 Reinhard Caspary                               #
 # <reinhard.caspary@phoenixd.uni-hannover.de>                            #
 # This program is free software under the terms of the MIT license.      #
 ##########################################################################
 #
-# This module provides the function getconfig() to read the default
+# This module provides the function load_config() to read the default
 # configuration parameters
 #
-# Parameter    | key
-# -------------+--------
-# author name  | author
-# author email | email
-# server URL   | server
-# server key   | key
+# Parameter           | key
+# --------------------+--------
+# author name         | author
+# author email        | email
+# author ORCiD        | orcid
+# author organization | organization
+# server URL          | server
+# server key          | key
 #
 # The values of these parameters are taken either from environment
 # variables or a config file. Both options are optional. Data from the

--- a/python/scidatacontainer/container.py
+++ b/python/scidatacontainer/container.py
@@ -27,8 +27,6 @@ import requests
 from .config import load_config
 from .filebase import BinaryFile, JsonFile, TextFile
 
-config = load_config()
-
 # Version of the implemented data model
 MODELVERSION = "1.0.0"
 
@@ -59,7 +57,7 @@ class AbstractContainer(ABC):
         - .bin <-> bytes
     """
 
-    _config = config
+    _config = None
     _suffixes = {"json": JsonFile, "txt": TextFile, "bin": BinaryFile}
     _classes = {dict: JsonFile, str: TextFile, bytes: BinaryFile}
     _formats = [TextFile]
@@ -69,10 +67,7 @@ class AbstractContainer(ABC):
         items: dict = None,
         file: str = None,
         uuid: str = None,
-        author: str = None,
-        email: str = None,
-        server: str = None,
-        key: str = None,
+        config: dict = None,
         compression: int = ZIP_DEFLATED,
         compresslevel: int = -1,
         **kwargs,
@@ -99,10 +94,7 @@ class AbstractContainer(ABC):
             "items": items,
             "file": file,
             "uuid": uuid,
-            "author": author,
-            "email": email,
-            "server": server,
-            "key": key,
+            "config": config,
             "compression": compression,
             "compresslevel": compresslevel,
         }
@@ -110,18 +102,20 @@ class AbstractContainer(ABC):
 
         self.__pre_init__()
 
-        # load variables from kwargs in namespace
+        # Load variables from kwargs in namespace
         n = SimpleNamespace(**self.kwargs)
 
         # Container must be mutable initially
         self.mutable = True
 
+        # Load configuration
+        if n.config is not None:
+            self._config = dict(n.config)
+        else:
+            self._config = load_config()
+
         # Store all items in the container
         if n.items is not None:
-            if n.author is not None:
-                n.items["meta.json"]["author"] = n.author
-            if n.email is not None:
-                n.items["meta.json"]["email"] = n.email
             self._store(n.items, True, False)
             self.mutable = not self["content.json"]["static"]
 
@@ -131,7 +125,9 @@ class AbstractContainer(ABC):
 
         # Download container from server
         elif n.uuid is not None:
-            self._download(uuid=n.uuid, server=n.server, key=n.key)
+            server = self._config["server"]
+            key = self._config["key"]
+            self._download(uuid=n.uuid, server=server, key=key)
 
         # No data source
         else:

--- a/python/scidatacontainer/container.py
+++ b/python/scidatacontainer/container.py
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright (c) 2023 Reinhard Caspary                                    #
+# Copyright (c) 2023-2024 Reinhard Caspary                               #
 # <reinhard.caspary@phoenixd.uni-hannover.de>                            #
 # This program is free software under the terms of the MIT license.      #
 ##########################################################################
@@ -359,9 +359,13 @@ class AbstractContainer(ABC):
         if "email" not in meta:
             meta["email"] = self._config["email"]
 
+        # Author ORCiD is optional
+        if "orcid" not in meta:
+            meta["orcid"] = self._config["orcid"]
+
         # Author affiliation is optional
         if "organization" not in meta:
-            meta["organization"] = ""
+            meta["organization"] = self._config["organization"]
 
         # Comment on dataset is optional
         if "comment" not in meta:


### PR DESCRIPTION
Package provides public method load_config() for author parameters in user code. Example:

    config = load_config(author="John Doe", email="john@doe.com", server="our.zdc.server.org")
    dc = Container(config=config)

Data sources: kwargs, config file, environmental variables.

Two new author parameters (for meta.json) added: "orcid" and "organization".